### PR TITLE
Completed test case for user registration with unfilled ZIP Code

### DIFF
--- a/page-objects/loginAndRegisterPage.ts
+++ b/page-objects/loginAndRegisterPage.ts
@@ -160,10 +160,18 @@ export class LoginAndRegisterPage{
     return user
     }
 
+    /**
+     * * Function that returns text content of locator for Alert Text Zip Code error message
+     * @returns 
+     */
     async getAlertText(){
         return await this.page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
     }
 
+    /**
+     * * Function that returns text content of locator for error message below ZIP Code input field
+     * @returns 
+     */
     async getAlertHelpBlock(){
         return await this.page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
     }

--- a/page-objects/loginAndRegisterPage.ts
+++ b/page-objects/loginAndRegisterPage.ts
@@ -159,4 +159,15 @@ export class LoginAndRegisterPage{
     //return user with all data
     return user
     }
+
+    async assertZIPCode(){
+        //Text content of alert box
+        const alertText = await this.page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
+        //Text content of error message below ZIP Code input
+        const alertHelpBlock = await this.page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
+        //Assert that in alert box it displays right text
+        expect(alertText?.replace('×', '')).toContain('Zip/postal code must be between 3 and 10 characters!')
+        //Assert that below ZIP Code input is displayed error message
+        expect(alertHelpBlock).toContain('Zip/postal code must be between 3 and 10 characters!')
+    }
 }

--- a/page-objects/loginAndRegisterPage.ts
+++ b/page-objects/loginAndRegisterPage.ts
@@ -160,14 +160,11 @@ export class LoginAndRegisterPage{
     return user
     }
 
-    async assertZIPCode(){
-        //Text content of alert box
-        const alertText = await this.page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
-        //Text content of error message below ZIP Code input
-        const alertHelpBlock = await this.page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
-        //Assert that in alert box it displays right text
-        expect(alertText?.replace('×', '')).toContain('Zip/postal code must be between 3 and 10 characters!')
-        //Assert that below ZIP Code input is displayed error message
-        expect(alertHelpBlock).toContain('Zip/postal code must be between 3 and 10 characters!')
+    async getAlertText(){
+        return await this.page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
+    }
+
+    async getAlertHelpBlock(){
+        return await this.page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
     }
 }

--- a/page-objects/loginAndRegisterPage.ts
+++ b/page-objects/loginAndRegisterPage.ts
@@ -1,5 +1,4 @@
 import { Page, expect } from '@playwright/test'
-import { HelperBase } from './helperBase';
 import { faker } from '@faker-js/faker';
 import { count } from 'console';
 import fs from 'fs'
@@ -47,7 +46,6 @@ export class LoginAndRegisterPage{
      * @param firstName - First name of a user
      * @param lastName - Last name of a user
      * @param email - Email of a user
-     * @param company - Company where user works
      * @param addressPrimary - Primary address of a user
      * @param city - City where user leaves
      * @param zipCode - ZIP/Postal code of a city where user lives
@@ -55,7 +53,7 @@ export class LoginAndRegisterPage{
      * @param password - Password 
      * @param passwordConfirm - Repeat above password (optional)
      */
-    async RegisterWithEmptyOrModifiedFields(firstName: string, lastName: string, email: string, company: string, addressPrimary: string, city: string, zipCode: string, loginName: string, password: string, passwordConfirm: string){
+    async RegisterWithEmptyOrModifiedFields(firstName: string, lastName: string, email: string, addressPrimary: string, city: string, zipCode: string, loginName: string, password: string, passwordConfirm: string){
         //If field is not undefined (empty string) fill that data to input field
         if(firstName !== undefined){
             await this.page.locator('#AccountFrm_firstname').fill(firstName)
@@ -65,9 +63,6 @@ export class LoginAndRegisterPage{
         }
         if(email !== undefined){
             await this.page.locator('#AccountFrm_email').fill(email)
-        }
-        if(company !== undefined){
-            await this.page.locator('#AccountFrm_company').fill(company)
         }
         if(addressPrimary !== undefined){
             await this.page.locator('#AccountFrm_address_1').fill(addressPrimary)
@@ -87,6 +82,10 @@ export class LoginAndRegisterPage{
         if(passwordConfirm !== undefined){
             await this.page.locator('#AccountFrm_confirm').fill(passwordConfirm)
         }
+        //Select region from dropdown
+        const regionDropdown = this.page.locator('#AccountFrm_zone_id')
+        await regionDropdown.click()
+        const regionOption = await regionDropdown.selectOption({label: 'Angus'})
         //Click on privacy policy checkbox
         const privacyPolicy = this.page.locator('#AccountFrm_agree')
         await privacyPolicy.click()

--- a/tests/invalidRegistration.spec.ts
+++ b/tests/invalidRegistration.spec.ts
@@ -18,6 +18,11 @@ test.describe('registration', () =>{
     test('user registration with unfilled ZIP CODE', async({page}) => {
         //Register using custom values
         await pm.loginAndRegister().RegisterWithEmptyOrModifiedFields("Test", "Test", "test12312412@test.com", "Test", "Test", "", "TeestAleksa", "test", "test")
-        await pm.loginAndRegister().assertZIPCode()
+        const alertText =  await pm.loginAndRegister().getAlertText()
+        //Assert that in alert box it displays right text
+        expect(alertText?.replace('×', '')).toContain('Zip/postal code must be between 3 and 10 characters!')
+        const alertHelpBlock = await pm.loginAndRegister().getAlertHelpBlock()
+        //Assert that below ZIP Code input is displayed error message
+        expect(alertHelpBlock).toContain('Zip/postal code must be between 3 and 10 characters!')
     })
 })

--- a/tests/invalidRegistration.spec.ts
+++ b/tests/invalidRegistration.spec.ts
@@ -1,0 +1,23 @@
+import { Page, expect, test } from "@playwright/test"
+import {PageManager} from "../page-objects/pageManager"
+
+
+test.describe('registration', () =>{
+    let pm:any
+    test.beforeEach( async({page}) =>{
+        //Instance of Page Manager Class
+        pm = new PageManager(page)
+        //Go to Automation Test Store Website
+        await page.goto('https://automationteststore.com/')
+        //Click on the Login/register in navigation bar
+        await pm.navigateTo().RegisterPage()
+        //Assert that URL is correct
+        await expect(page).toHaveURL('https://automationteststore.com/index.php?rt=account/create')
+    })
+
+    test('user registration with unfilled ZIP CODE', async({page}) => {
+        //Register using custom values
+        await pm.loginAndRegister().RegisterWithEmptyOrModifiedFields("Test", "Test", "test12312412@test.com", "Test", "Test", "", "TeestAleksa", "test", "test")
+        await pm.loginAndRegister().assertZIPCode()
+    })
+})

--- a/tests/loginAndRegister.spec.ts
+++ b/tests/loginAndRegister.spec.ts
@@ -3,9 +3,10 @@ import {PageManager} from "../page-objects/pageManager"
 
 
 test.describe('registration', () =>{
+    let pm:any
     test.beforeEach( async({page}) =>{
         //Instance of Page Manager Class
-        const pm = new PageManager(page)
+        pm = new PageManager(page)
         //Go to Automation Test Store Website
         await page.goto('https://automationteststore.com/')
         //Click on the Login/register in navigation bar
@@ -15,10 +16,22 @@ test.describe('registration', () =>{
     })
     
     test('user registration using valid credentials', async({page}) =>{
-        const pm = new PageManager(page)
         //Register using all valid credentials
         await pm.loginAndRegister().RegisterWithAllCredentialsAndChecks()
         //Assert that account has been created
         await expect(page.getByText(' Your Account Has Been Created!')).toHaveText(' Your Account Has Been Created!')
+    })
+
+    test('user registration with unfilled ZIP CODE', async({page}) => {
+        //Register using custom values
+        await pm.loginAndRegister().RegisterWithEmptyOrModifiedFields("Test", "Test", "test12312412@test.com", "Test", "Test", "", "TeestAleksa", "test", "test")
+        //Text content of alert box
+        const alertText = await page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
+        //Text content of error message below ZIP Code input
+        const alertHelpBlock = await page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
+        //Assert that in alert box it displays right text
+        expect(alertText?.replace('×', '')).toContain('Zip/postal code must be between 3 and 10 characters!')
+        //Assert that below ZIP Code input is displayed error message
+        expect(alertHelpBlock).toContain('Zip/postal code must be between 3 and 10 characters!')
     })
 })

--- a/tests/loginAndRegister.spec.ts
+++ b/tests/loginAndRegister.spec.ts
@@ -21,17 +21,4 @@ test.describe('registration', () =>{
         //Assert that account has been created
         await expect(page.getByText(' Your Account Has Been Created!')).toHaveText(' Your Account Has Been Created!')
     })
-
-    test('user registration with unfilled ZIP CODE', async({page}) => {
-        //Register using custom values
-        await pm.loginAndRegister().RegisterWithEmptyOrModifiedFields("Test", "Test", "test12312412@test.com", "Test", "Test", "", "TeestAleksa", "test", "test")
-        //Text content of alert box
-        const alertText = await page.getByText(' Zip/postal code must be between 3 and 10 characters!').first().textContent()
-        //Text content of error message below ZIP Code input
-        const alertHelpBlock = await page.getByText('Zip/postal code must be between 3 and 10 characters!', { exact: true }).textContent()
-        //Assert that in alert box it displays right text
-        expect(alertText?.replace('×', '')).toContain('Zip/postal code must be between 3 and 10 characters!')
-        //Assert that below ZIP Code input is displayed error message
-        expect(alertHelpBlock).toContain('Zip/postal code must be between 3 and 10 characters!')
-    })
 })


### PR DESCRIPTION
Created new test case where user navigates to register page and tries to register with unfilled ZIP Code, assertion for error messages in alert box and below ZIP Code input field. Removed instances from all test cases and declared `let pm:any` between `test.describe` and `test.beforeEach` after that i created instance of PageManager in `test.beforeEach`.